### PR TITLE
Add argument for output directory

### DIFF
--- a/bin/auto-reveal.js
+++ b/bin/auto-reveal.js
@@ -63,6 +63,17 @@ program
 program
 	.command('build')
 	.description('Build a static copy of your presentation.')
-	.action(() => build(config));
+	.option('-o, --outDir <path>', 'Output directory', config.build.outDir)
+	.action((options) =>
+		build({
+			...config,
+			build: {
+				...config.build,
+				outDir: options.outDir
+					? path.resolve(cwd, options.outDir)
+					: config.build.outDir,
+			},
+		}),
+	);
 
 program.parse();

--- a/bin/auto-reveal.js
+++ b/bin/auto-reveal.js
@@ -2,12 +2,12 @@
 
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
 import { build, createServer } from 'vite';
 import { ViteEjsPlugin as viteEjsPlugin } from 'vite-plugin-ejs';
 import { getTheme, getTitle } from '../lib/utils.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
-const argv = process.argv.slice(2);
 const cwd = process.cwd();
 
 const themeFolder = path.dirname(getTheme());
@@ -47,8 +47,22 @@ async function start() {
 	server.bindCLIShortcuts({ print: true });
 }
 
-if (!argv[0] || argv[0] === 'start') {
-	start();
-} else if (argv[0] === 'build') {
-	build(config);
-}
+const program = new Command();
+
+program.name(process.env.npm_package_name);
+program.description(process.env.npm_package_description);
+program.version(process.env.npm_package_version);
+
+program
+	.command('start', {
+		isDefault: true,
+	})
+	.description('Live-reloading server for your slides.')
+	.action(start);
+
+program
+	.command('build')
+	.description('Build a static copy of your presentation.')
+	.action(() => build(config));
+
+program.parse();

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "auto-reveal",
   "version": "0.2.1",
-  "description": "",
-  "keywords": [],
+  "description": "The command-line interface for reveal.js presentations.",
+  "keywords": ["reveal.js", "cli", "markdown"],
   "repository": {
     "type": "git",
     "url": "git@github.com:mainmatter/auto-reveal.git"
@@ -15,11 +15,12 @@
     "auto-reveal": "./bin/auto-reveal.js"
   },
   "scripts": {
-    "format": "biome check --apply .",
+    "format": "biome check --write .",
     "lint": "biome check .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "commander": "^12.1.0",
     "reveal.js": "5.1.0",
     "vite": "5.4.0",
     "vite-plugin-ejs": "1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       reveal.js:
         specifier: 5.1.0
         version: 5.1.0
@@ -544,6 +547,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1871,6 +1878,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  commander@12.1.0: {}
 
   concat-map@0.0.1: {}
 


### PR DESCRIPTION
Provides new `-o/--outDir` arguments to the `build` command.

Replaces the makeshift command parsing with `commander`, adding version, help, and description along the way. 

Previous behavior is kept (launching `auto-reveal` is the same as `auto-reveal start`)

Closes #16 