### PR TITLE
Use relative base root for Vite

### DIFF
--- a/bin/auto-reveal.js
+++ b/bin/auto-reveal.js
@@ -15,6 +15,7 @@ const config = {
 	configFile: false,
 	root: path.join(__dirname, '..', 'src'),
 	publicDir: path.join(cwd, 'public'),
+	base: './',
 	server: {
 		port: 1337,
 		fs: {


### PR DESCRIPTION
This makes the presentations more portable.

Closes #15