### PR TITLE
Use localeCompare instead of custom regex

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,13 +13,12 @@ const markdownFiles = import.meta.glob('slides/*.md', {
 	eager: true,
 });
 
-const sortedMarkdownFiles = Object.entries(markdownFiles).sort(([a], [b]) => {
-	const regex = /slides\/(\d+)-/;
-	const [, aNumb] = regex.exec(a);
-	const [, bNumb] = regex.exec(b);
-
-	return Number(aNumb) - Number(bNumb);
-});
+const sortedMarkdownFiles = Object.entries(markdownFiles).sort(([a], [b]) =>
+	a.localeCompare(b, undefined, {
+		numeric: true,
+		sensitivity: 'base',
+	}),
+);
 
 const sections = sortedMarkdownFiles.map(
 	([, content]) => `


### PR DESCRIPTION
Sorting still behaves the same but it won't break if you have files that do not match the recommended `000-*.md` pattern.