### PR TITLE
Bugfix: Don't crash when devDependencies are not defined

### DIFF
--- a/lib/common-utils.cjs
+++ b/lib/common-utils.cjs
@@ -24,8 +24,8 @@ function getPackageJson(cwd = process.cwd()) {
 function getThemePackage() {
 	const packageJson = getPackageJson();
 	return [
-		...Object.keys(packageJson.dependencies),
-		...Object.keys(packageJson.devDependencies),
+		...Object.keys(packageJson.dependencies ?? {}),
+		...Object.keys(packageJson.devDependencies ?? {}),
 	].find((name) => name.startsWith('auto-reveal-theme-'));
 }
 


### PR DESCRIPTION
Closes #55 