### PR TITLE
Make start the default command for auto-reveal

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -11,7 +11,9 @@ program.description(process.env.npm_package_description);
 program.version(process.env.npm_package_version);
 
 program
-	.command('start')
+	.command('start', {
+		isDefault: true,
+	})
 	.description('Live-reloading server for your slides.')
 	.option('-p, --port <port>', 'Port to run the server on', 1337)
 	.action(start);

--- a/tests/program.test.js
+++ b/tests/program.test.js
@@ -16,6 +16,12 @@ describe('auto-reveal CLI', () => {
 		vi.clearAllMocks();
 	});
 
+	test('Using auto-reveal without any command triggers the start function', async () => {
+		await program.parseAsync(['node', 'auto-reveal']);
+
+		expect(start).toBeCalledTimes(1);
+	});
+
 	test('Using auto-reveal start triggers the start function', async () => {
 		await program.parseAsync(['node', 'auto-reveal', 'start']);
 


### PR DESCRIPTION
Bring back the original default