### PR TITLE
Add `add` command to create new slide files

### DIFF
--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -2,9 +2,10 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { globby } from 'globby';
 import { deburr, kebabCase } from 'lodash-es';
-import { ascii } from '../utils.js';
+import { ascii, printAutoRevealMessage, toNearest } from '../utils.js';
 
 const DIGITS = 3;
+export const DEFAULT_INCREMENT = 10;
 
 const filenameTemplate = (number, digits, title) =>
 	`${number.toString().padStart(digits, '0')}${
@@ -17,7 +18,10 @@ const slideTemplate = (title) =>
 This note is only visible to the presenter.
 `;
 
-export async function nextSlideNumber() {
+const createMessageTemplate = (filename) => `Created ./slides/${filename}
+Hint: Create a vertical slide by adding "---" to that file.`;
+
+export async function nextSlideNumber(increment = DEFAULT_INCREMENT) {
 	const slides = await globby('slides/*.md');
 
 	if (slides.length === 0) {
@@ -26,15 +30,20 @@ export async function nextSlideNumber() {
 
 	const lastSlide = slides.at(-1);
 	const lastSlideName = path.basename(lastSlide);
+	const lastSlideNumber = Number.parseInt(lastSlideName, 10);
 
-	return Number.parseInt(lastSlideName, 10) + 1;
+	return toNearest(lastSlideNumber, increment) + Number.parseInt(increment, 10);
 }
 
 export async function writeNewSlide(
 	title,
-	{ writeTitleToFileName = true, cwd = process.cwd() } = {},
+	{
+		writeTitleToFileName = true,
+		cwd = process.cwd(),
+		increment = DEFAULT_INCREMENT,
+	} = {},
 ) {
-	const number = await nextSlideNumber();
+	const number = await nextSlideNumber(increment);
 	const filename = filenameTemplate(
 		number,
 		DIGITS,
@@ -46,15 +55,14 @@ export async function writeNewSlide(
 	return { filename };
 }
 
-export async function add(title, { increment = 1 } = {}) {
+export async function add(title, { increment = DEFAULT_INCREMENT } = {}) {
 	const { filename } = await writeNewSlide(
 		title ? title.join(' ') : undefined,
 		{
+			increment,
 			cwd: path.join(process.cwd(), 'slides'),
 		},
 	);
 
-	console.log(
-		`auto-reveal\n\n  Created ./slides/${filename}\n  Create a vertical slide by adding "---" to that file.`,
-	);
+	printAutoRevealMessage(createMessageTemplate(filename));
 }

--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -1,0 +1,60 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { globby } from 'globby';
+import { deburr, kebabCase } from 'lodash-es';
+import { ascii } from '../utils.js';
+
+const DIGITS = 3;
+
+const filenameTemplate = (number, digits, title) =>
+	`${number.toString().padStart(digits, '0')}${
+		title ? `-${kebabCase(ascii(deburr(title)))}` : ''
+	}.md`;
+
+const slideTemplate = (title) =>
+	`${title ? `# ${title}\n\n` : ''}Note:
+
+This note is only visible to the presenter.
+`;
+
+export async function nextSlideNumber() {
+	const slides = await globby('slides/*.md');
+
+	if (slides.length === 0) {
+		return 0;
+	}
+
+	const lastSlide = slides.at(-1);
+	const lastSlideName = path.basename(lastSlide);
+
+	return Number.parseInt(lastSlideName, 10) + 1;
+}
+
+export async function writeNewSlide(
+	title,
+	{ writeTitleToFileName = true, cwd = process.cwd() } = {},
+) {
+	const number = await nextSlideNumber();
+	const filename = filenameTemplate(
+		number,
+		DIGITS,
+		writeTitleToFileName ? title : '',
+	);
+
+	await fs.writeFile(path.join(cwd, filename), slideTemplate(title));
+
+	return { filename };
+}
+
+export async function add(title, { increment = 1 } = {}) {
+	const { filename } = await writeNewSlide(
+		title ? title.join(' ') : undefined,
+		{
+			cwd: path.join(process.cwd(), 'slides'),
+		},
+	);
+
+	console.log(
+		`auto-reveal\n\n  Created ./slides/${filename}\n  Create a vertical slide by adding "---" to that file.`,
+	);
+}

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -2,8 +2,16 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { deburr, kebabCase } from 'lodash-es';
 import { mkdirp } from 'mkdirp';
-import { ascii } from '../utils.js';
+import { ascii, printAutoRevealMessage } from '../utils.js';
 import { writeNewSlide } from './add.js';
+
+const createMessageTemplate = (
+	targetDirectory,
+) => `Setting up your presentation in
+${targetDirectory}
+
+Hint: Create new slides by running "auto-reveal add".
+Hint: Create new vertical slides by adding "---" inside your slide markdown file.`;
 
 export async function create(target, { name }) {
 	const targetDirectory = target ? path.resolve(target) : process.cwd();
@@ -14,9 +22,7 @@ export async function create(target, { name }) {
 		await mkdirp(targetDirectory);
 	}
 
-	console.log(
-		`\nauto-reveal\n\n  Setting up your presentation in \n  ${targetDirectory}\n\n  Hint: Create new slides by running "auto-reveal add". \n  Hint: Create new vertical slides by adding "---" inside your slide markdown file.\n`,
-	);
+	printAutoRevealMessage(createMessageTemplate(targetDirectory));
 
 	await mkdirp(path.join(targetDirectory, 'slides'));
 	await mkdirp(path.join(targetDirectory, 'public'));

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { deburr, kebabCase } from 'lodash-es';
 import { mkdirp } from 'mkdirp';
+import { ascii } from '../utils.js';
+import { writeNewSlide } from './add.js';
 
 export async function create(target, { name }) {
 	const targetDirectory = target ? path.resolve(target) : process.cwd();
@@ -13,23 +15,22 @@ export async function create(target, { name }) {
 	}
 
 	console.log(
-		`\nauto-reveal\n\n  Setting up your presentation in \n  ${
-			target ? targetDirectory : 'current directory'
-		}`,
+		`\nauto-reveal\n\n  Setting up your presentation in \n  ${targetDirectory}\n\n  Hint: Create new slides by running "auto-reveal add". \n  Hint: Create new vertical slides by adding "---" inside your slide markdown file.\n`,
 	);
 
 	await mkdirp(path.join(targetDirectory, 'slides'));
 	await mkdirp(path.join(targetDirectory, 'public'));
 
-	await fs.writeFile(
-		path.join(targetDirectory, 'slides', '000.md'),
-		`# ${name}`,
-	);
+	await writeNewSlide(name, {
+		cwd: path.join(targetDirectory, 'slides'),
+		writeTitleToFileName: false,
+	});
+
 	await fs.writeFile(
 		path.join(targetDirectory, 'package.json'),
 		`${JSON.stringify(
 			{
-				name: kebabCase(deburr(name)),
+				name: kebabCase(ascii(deburr(name))),
 				version: '0.0.0',
 				scripts: {
 					'auto-reveal': 'auto-reveal',

--- a/lib/program.js
+++ b/lib/program.js
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 
+import { add } from './commands/add.js';
 import { build } from './commands/build.js';
 import { create } from './commands/create.js';
 import { start } from './commands/start.js';
@@ -32,6 +33,13 @@ program
 		'Name of the presentation (default: name of current directory)',
 	)
 	.action(create);
+
+program
+	.command('add')
+	.alias('slide')
+	.description('Add a new slide to your presentation.')
+	.argument('[title...]', 'Title of the slide')
+	.action(add);
 
 program
 	.command('build')

--- a/lib/program.js
+++ b/lib/program.js
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 
-import { add } from './commands/add.js';
+import { DEFAULT_INCREMENT, add } from './commands/add.js';
 import { build } from './commands/build.js';
 import { create } from './commands/create.js';
 import { start } from './commands/start.js';
@@ -39,6 +39,11 @@ program
 	.alias('slide')
 	.description('Add a new slide to your presentation.')
 	.argument('[title...]', 'Title of the slide')
+	.option(
+		'-i, --increment <increment>',
+		'Increment of the slide prefix',
+		DEFAULT_INCREMENT,
+	)
 	.action(add);
 
 program

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,10 @@ export function getTitle(defaultTitle = 'auto-reveal') {
 	return process.env.npm_package_name ?? defaultTitle;
 }
 
+export function ascii(str) {
+	return str.replace(/[^\x20-\x7E]/g, '');
+}
+
 const { getTheme, getThemePackage, getRevealJsTheme, readJsonSync } = utils;
 
 export { getTheme, getThemePackage, getRevealJsTheme, readJsonSync };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,6 +24,14 @@ export function ascii(str) {
 	return str.replace(/[^\x20-\x7E]/g, '');
 }
 
+export const toNearest = (number, base = 10) => Math.ceil(number / base) * base;
+
+export function printAutoRevealMessage(message = '') {
+	console.log(
+		`\nauto-reveal\n\n${message.trim().replace(/^(?!\s*$)/gm, '  ')}\n`,
+	);
+}
+
 const { getTheme, getThemePackage, getRevealJsTheme, readJsonSync } = utils;
 
 export { getTheme, getThemePackage, getRevealJsTheme, readJsonSync };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "commander": "^13.1.0",
     "fixturify": "^3.0.0",
+    "globby": "^14.1.0",
     "lodash-es": "^4.17.21",
     "mkdirp": "^3.0.1",
     "reveal.js": "5.2.0",
@@ -42,7 +43,6 @@
     "@biomejs/biome": "1.9.4",
     "execa": "^9.5.2",
     "fixturify-project": "^7.1.3",
-    "globby": "^14.1.0",
     "release-plan": "0.16.0",
     "vitest": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       fixturify:
         specifier: ^3.0.0
         version: 3.0.0
+      globby:
+        specifier: ^14.1.0
+        version: 14.1.0
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -45,9 +48,6 @@ importers:
       fixturify-project:
         specifier: ^7.1.3
         version: 7.1.3
-      globby:
-        specifier: ^14.1.0
-        version: 14.1.0
       release-plan:
         specifier: 0.16.0
         version: 0.16.0

--- a/tests/commands/add.test.js
+++ b/tests/commands/add.test.js
@@ -1,0 +1,86 @@
+import { execa } from 'execa';
+import fixturify from 'fixturify';
+import { describe, expect, it } from 'vitest';
+
+import { makeFolder } from '../helpers.js';
+
+describe('add command tests', () => {
+	it('adds a new slide in an empty slides folder', async () => {
+		const { cwd } = await makeFolder({
+			files: {
+				slides: {},
+			},
+		});
+
+		const result = await execa({
+			cwd,
+		})`${process.cwd()}/bin/auto-reveal add`;
+
+		const fixtures = fixturify.readSync(cwd);
+
+		expect(result.stdout).toStrictEqual(
+			'auto-reveal\n\n  Created ./slides/000.md\n  Create a vertical slide by adding "---" to that file.',
+		);
+		expect(result.exitCode).to.equal(0);
+		expect(fixtures).toStrictEqual({
+			slides: {
+				'000.md': 'Note:\n\nThis note is only visible to the presenter.\n',
+			},
+		});
+	});
+
+	it('adds a new slide without a title', async () => {
+		const { cwd } = await makeFolder({
+			files: {
+				slides: {
+					'000.md': '# Slide 1',
+				},
+			},
+		});
+
+		const result = await execa({
+			cwd,
+		})`${process.cwd()}/bin/auto-reveal add`;
+
+		const fixtures = fixturify.readSync(cwd);
+
+		expect(result.stdout).toStrictEqual(
+			'auto-reveal\n\n  Created ./slides/001.md\n  Create a vertical slide by adding "---" to that file.',
+		);
+		expect(result.exitCode).to.equal(0);
+		expect(fixtures).toStrictEqual({
+			slides: {
+				'000.md': '# Slide 1',
+				'001.md': 'Note:\n\nThis note is only visible to the presenter.\n',
+			},
+		});
+	});
+
+	it('adds a new slide with a title', async () => {
+		const { cwd } = await makeFolder({
+			files: {
+				slides: {
+					'000.md': '# Slide 1',
+				},
+			},
+		});
+
+		const result = await execa({
+			cwd,
+		})`${process.cwd()}/bin/auto-reveal add 👋 Hallöle`;
+
+		const fixtures = fixturify.readSync(cwd);
+
+		expect(result.stdout).toStrictEqual(
+			'auto-reveal\n\n  Created ./slides/001-hallole.md\n  Create a vertical slide by adding "---" to that file.',
+		);
+		expect(result.exitCode).to.equal(0);
+		expect(fixtures).toStrictEqual({
+			slides: {
+				'000.md': '# Slide 1',
+				'001-hallole.md':
+					'# 👋 Hallöle\n\nNote:\n\nThis note is only visible to the presenter.\n',
+			},
+		});
+	});
+});

--- a/tests/commands/add.test.js
+++ b/tests/commands/add.test.js
@@ -19,7 +19,7 @@ describe('add command tests', () => {
 		const fixtures = fixturify.readSync(cwd);
 
 		expect(result.stdout).toStrictEqual(
-			'auto-reveal\n\n  Created ./slides/000.md\n  Create a vertical slide by adding "---" to that file.',
+			'\nauto-reveal\n\n  Created ./slides/000.md\n  Hint: Create a vertical slide by adding "---" to that file.\n',
 		);
 		expect(result.exitCode).to.equal(0);
 		expect(fixtures).toStrictEqual({
@@ -45,13 +45,50 @@ describe('add command tests', () => {
 		const fixtures = fixturify.readSync(cwd);
 
 		expect(result.stdout).toStrictEqual(
-			'auto-reveal\n\n  Created ./slides/001.md\n  Create a vertical slide by adding "---" to that file.',
+			'\nauto-reveal\n\n  Created ./slides/010.md\n  Hint: Create a vertical slide by adding "---" to that file.\n',
 		);
 		expect(result.exitCode).to.equal(0);
 		expect(fixtures).toStrictEqual({
 			slides: {
 				'000.md': '# Slide 1',
-				'001.md': 'Note:\n\nThis note is only visible to the presenter.\n',
+				'010.md': 'Note:\n\nThis note is only visible to the presenter.\n',
+			},
+		});
+	});
+
+	it('adds a new slide with a custom increment', async () => {
+		const { cwd } = await makeFolder({
+			files: {
+				slides: {
+					'003.md': '# Slide 1',
+				},
+			},
+		});
+
+		const result1 = await execa({
+			cwd,
+		})`${process.cwd()}/bin/auto-reveal add -i 5`;
+
+		expect(result1.stdout).toStrictEqual(
+			'\nauto-reveal\n\n  Created ./slides/010.md\n  Hint: Create a vertical slide by adding "---" to that file.\n',
+		);
+		expect(result1.exitCode).to.equal(0);
+
+		const result2 = await execa({
+			cwd,
+		})`${process.cwd()}/bin/auto-reveal add -i 5`;
+
+		expect(result2.stdout).toStrictEqual(
+			'\nauto-reveal\n\n  Created ./slides/015.md\n  Hint: Create a vertical slide by adding "---" to that file.\n',
+		);
+		expect(result2.exitCode).to.equal(0);
+
+		const fixtures = fixturify.readSync(cwd);
+		expect(fixtures).toStrictEqual({
+			slides: {
+				'003.md': '# Slide 1',
+				'010.md': 'Note:\n\nThis note is only visible to the presenter.\n',
+				'015.md': 'Note:\n\nThis note is only visible to the presenter.\n',
 			},
 		});
 	});
@@ -72,13 +109,13 @@ describe('add command tests', () => {
 		const fixtures = fixturify.readSync(cwd);
 
 		expect(result.stdout).toStrictEqual(
-			'auto-reveal\n\n  Created ./slides/001-hallole.md\n  Create a vertical slide by adding "---" to that file.',
+			'\nauto-reveal\n\n  Created ./slides/010-hallole.md\n  Hint: Create a vertical slide by adding "---" to that file.\n',
 		);
 		expect(result.exitCode).to.equal(0);
 		expect(fixtures).toStrictEqual({
 			slides: {
 				'000.md': '# Slide 1',
-				'001-hallole.md':
+				'010-hallole.md':
 					'# 👋 Hallöle\n\nNote:\n\nThis note is only visible to the presenter.\n',
 			},
 		});

--- a/tests/commands/create.test.js
+++ b/tests/commands/create.test.js
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { execa } from 'execa';
 import fixturify from 'fixturify';
 import { describe, expect, it } from 'vitest';
@@ -15,14 +16,19 @@ describe('create command tests', () => {
 		const fixtures = fixturify.readSync(cwd);
 
 		expect(result.exitCode).to.equal(0);
-		expect(result.stdout).to.include('\nauto-reveal\n');
+		expect(result.stdout).toStrictEqual(
+			`\nauto-reveal\n\n  Setting up your presentation in \n  ${cwd}\n\n  Hint: Create new slides by running "auto-reveal add". \n  Hint: Create new vertical slides by adding "---" inside your slide markdown file.\n`,
+		);
 		expect(fixtures).toStrictEqual({
 			public: {},
 			slides: {
-				'000.md': expect.stringMatching(/^# tmp-/),
+				'000.md': expect.stringMatching(/.*/),
 			},
 			'package.json': expect.stringMatching(/.*/),
 		});
+		expect(fixtures.slides['000.md']).toStrictEqual(
+			`# ${path.basename(cwd)}\n\nNote:\n\nThis note is only visible to the presenter.\n`,
+		);
 		expect(JSON.parse(fixtures['package.json'])).toStrictEqual({
 			name: expect.stringMatching(/^tmp-/),
 			version: '0.0.0',

--- a/tests/commands/create.test.js
+++ b/tests/commands/create.test.js
@@ -17,7 +17,7 @@ describe('create command tests', () => {
 
 		expect(result.exitCode).to.equal(0);
 		expect(result.stdout).toStrictEqual(
-			`\nauto-reveal\n\n  Setting up your presentation in \n  ${cwd}\n\n  Hint: Create new slides by running "auto-reveal add". \n  Hint: Create new vertical slides by adding "---" inside your slide markdown file.\n`,
+			`\nauto-reveal\n\n  Setting up your presentation in\n  ${cwd}\n\n  Hint: Create new slides by running "auto-reveal add".\n  Hint: Create new vertical slides by adding "---" inside your slide markdown file.\n`,
 		);
 		expect(fixtures).toStrictEqual({
 			public: {},

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+import { toNearest } from '../lib/utils';
+
+describe('Utils', () => {
+	test('toNearest', async () => {
+		expect(toNearest(3, 5)).toBe(5);
+		expect(toNearest(7, 10)).toBe(10);
+		expect(toNearest(15, 15)).toBe(15);
+		expect(toNearest(10, 20)).toBe(20);
+		expect(toNearest(10, 5)).toBe(10);
+		expect(toNearest(0, 10)).toBe(0);
+	});
+});


### PR DESCRIPTION
- automatically increments the number before the slide (with optionally adjustable increment)
- passed titles are added as a first headline and are added to the filename
- a sample `Note:` is added
- added friendly stdout text with explainer for vertical slide separators
- code is re-used for the `create` command

